### PR TITLE
accept_incomplete2: fix for #81

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
 
 buildscript {
 	repositories {
+		mavenCentral()
 		maven {
 			url "https://repo.spring.io/plugins-release"
 			content {
@@ -23,7 +24,9 @@ buildscript {
 				// can be tested with gradle --refresh-dependencies -i
 				// See https://stackoverflow.com/a/56670635/1484823
 				// See https://docs.gradle.org/5.4.1/userguide/declaring_repositories.html#declaring_a_repository_filter
-				excludeGroupByRegex "org\\.jfrog.*"
+				includeGroupByRegex "(io\\.spring.*)|(org\\.springframework.*)"
+//				excludeGroupByRegex "org\\.jfrog.*"
+//				excludeGroupByRegex "com\\.puppycrawl.*"
 			}
 		}
 	}

--- a/osb-cmdb/docs/TODO.md
+++ b/osb-cmdb/docs/TODO.md
@@ -1,3 +1,13 @@
+accept_incomplete bug
+* How to test it ?
+   * AcceptanceTests to require provision with accept_incomplete & broker to reject it
+      * Pb acceptance tests currently use CloudFoundryOperations abstraction which always specifies `acceptsIncomplete(true)`
+         * [ ] Use low level cloudfoundry client just to assert accept_incomplete=false is properly propagated 
+         * [ ] create hook method in base class
+         * [ ] collect params (service instance, definition....) to reuse them
+      
+
+
 
 * [ ] Release new version
 * [x] Refine default log level in paas-templates 

--- a/osb-cmdb/docs/TODO.md
+++ b/osb-cmdb/docs/TODO.md
@@ -1,11 +1,3 @@
-accept_incomplete bug
-* How to test it ?
-   * AcceptanceTests to require provision with accept_incomplete & broker to reject it
-      * Pb acceptance tests currently use CloudFoundryOperations abstraction which always specifies `acceptsIncomplete(true)`
-         * [ ] Use low level cloudfoundry client just to assert accept_incomplete=false is properly propagated 
-         * [ ] create hook method in base class
-         * [ ] collect params (service instance, definition....) to reuse them
-      
 
 
 

--- a/osb-cmdb/docs/impl-notes/accept_incomplete_bug.md
+++ b/osb-cmdb/docs/impl-notes/accept_incomplete_bug.md
@@ -1,0 +1,13 @@
+https://github.com/orange-cloudfoundry/osb-cmdb/issues/81
+
+accept_incomplete bug
+* How to test it ?
+   * AcceptanceTests to require provision with accept_incomplete & broker to reject it
+      * Pb acceptance tests currently use CloudFoundryOperations abstraction which always specifies `acceptsIncomplete(true)`
+         * [x] Use low level cloudfoundry client just to specify accept_incomplete=false, and thus assert the request flag is properly propagated
+            * Pb: brokered service plan guid needs to be looked up from service name and plan name 
+               * This pulls many code from cf-java-client
+                  * eventually plan to contribute PR to reduce duplication
+         * [ ] ~~create hook method in base class~~
+             * Pb: this breaks other test cases
+         * [x] create dedicated test class

--- a/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/OsbCmdbBrokerConfiguration.java
+++ b/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/OsbCmdbBrokerConfiguration.java
@@ -8,6 +8,7 @@ import com.orange.oss.osbcmdb.serviceinstance.MaintenanceInfoFormatterService;
 import com.orange.oss.osbcmdb.serviceinstance.OsbCmdbServiceInstance;
 import com.orange.oss.osbcmdb.serviceinstance.ServiceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.ASyncFailedCreateBackingSpaceInstanceInterceptor;
+import com.orange.oss.osbcmdb.testfixtures.ASyncOnlyBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.ASyncStalledCreateBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.ASyncStalledDeleteBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.ASyncStalledUpdateBackingSpaceInstanceInterceptor;
@@ -19,6 +20,7 @@ import com.orange.oss.osbcmdb.testfixtures.BackingServiceBindingInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncFailedCreateBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncFailedDeleteBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncFailedUpdateBackingSpaceInstanceInterceptor;
+import com.orange.oss.osbcmdb.testfixtures.SyncOnlyBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncSuccessfulBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncSuccessfulBackingSpaceInstanceWithoutDashboardInInitialVersionInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncTimeoutCreateBackingSpaceInstanceInterceptor;
@@ -61,6 +63,20 @@ public class OsbCmdbBrokerConfiguration {
 	public ServiceInstanceInterceptor acceptanceTestBackingServiceInstanceInterceptor(
 		CloudFoundryTargetProperties targetProperties) {
 		return new SyncSuccessfulBackingSpaceInstanceInterceptor(targetProperties.getDefaultSpace());
+	}
+
+	@Bean
+	@Profile("acceptanceTests & SyncOnlyBackingSpaceInstanceInterceptor")
+	public ServiceInstanceInterceptor acceptanceTestSyncOnlyBackingSpaceInstanceInterceptor(
+		CloudFoundryTargetProperties targetProperties) {
+		return new SyncOnlyBackingSpaceInstanceInterceptor(targetProperties.getDefaultSpace());
+	}
+
+	@Bean
+	@Profile("acceptanceTests & ASyncOnlyBackingSpaceInstanceInterceptor")
+	public ServiceInstanceInterceptor acceptanceTestASyncOnlyBackingSpaceInstanceInterceptor(
+		CloudFoundryTargetProperties targetProperties) {
+		return new ASyncOnlyBackingSpaceInstanceInterceptor(targetProperties.getDefaultSpace());
 	}
 
 	@Bean

--- a/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/serviceinstance/OsbCmdbServiceInstance.java
+++ b/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/serviceinstance/OsbCmdbServiceInstance.java
@@ -230,6 +230,7 @@ public class OsbCmdbServiceInstance extends AbstractOsbCmdbService implements Se
 						.servicePlanId(backingServicePlanId)
 						.parameters(formatParameters(metaData, request.getParameters()))
 						.spaceId(spaceId)
+						.acceptsIncomplete(request.isAsyncAccepted())
 						.build())
 					.block();
 
@@ -532,6 +533,7 @@ public class OsbCmdbServiceInstance extends AbstractOsbCmdbService implements Se
 					.servicePlanId(backingServicePlanId)
 					.parameters(formatParameters(metaData, request.getParameters()))
 					.maintenanceInfo(formattedForBackendInstanceMI)
+					.acceptsIncomplete(request.isAsyncAccepted())
 					.build())
 				.block();
 

--- a/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/testfixtures/ASyncOnlyBackingSpaceInstanceInterceptor.java
+++ b/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/testfixtures/ASyncOnlyBackingSpaceInstanceInterceptor.java
@@ -1,0 +1,31 @@
+package com.orange.oss.osbcmdb.testfixtures;
+
+import reactor.core.publisher.Mono;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceResponse;
+
+/**
+ * This service rejects any provision/update/delete which is requested with accept_incomplete=false
+ */
+public class ASyncOnlyBackingSpaceInstanceInterceptor extends BaseServiceInstanceBackingSpaceInstanceInterceptor {
+
+	private static final Logger LOG = Loggers.getLogger(ASyncOnlyBackingSpaceInstanceInterceptor.class);
+
+	public ASyncOnlyBackingSpaceInstanceInterceptor(String defaultSpaceName) {
+		super(defaultSpaceName);
+	}
+
+	@Override
+	public Mono<CreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request) {
+		if (! request.isAsyncAccepted()) {
+			throw new ServiceBrokerAsyncRequiredException("ASyncOnlyBackingSpaceInstanceInterceptor is " +
+				"expecting accept_incomplete=true ");
+		}
+		return super.createServiceInstance(request);
+	}
+
+}

--- a/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/testfixtures/AsyncSuccessfulCreateUpdateDeleteBackingSpaceInstanceInterceptor.java
+++ b/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/testfixtures/AsyncSuccessfulCreateUpdateDeleteBackingSpaceInstanceInterceptor.java
@@ -4,6 +4,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceResponse;
 import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
@@ -26,6 +27,11 @@ public class AsyncSuccessfulCreateUpdateDeleteBackingSpaceInstanceInterceptor ex
 
 	@Override
 	public Mono<CreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request) {
+		if (! request.isAsyncAccepted()) {
+			throw new ServiceBrokerAsyncRequiredException("AsyncSuccessfulCreateUpdateDeleteBackingSpaceInstanceInterceptor is " +
+				"expecting accept_incomplete=false");
+		}
+
 		provisionnedInstanceGuids.add(request.getServiceInstanceId());
 		provisionnedInstanceParams.put(request.getServiceInstanceId(), request.getParameters());
 		return Mono.just(CreateServiceInstanceResponse.builder()

--- a/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/testfixtures/SyncOnlyBackingSpaceInstanceInterceptor.java
+++ b/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/testfixtures/SyncOnlyBackingSpaceInstanceInterceptor.java
@@ -1,0 +1,31 @@
+package com.orange.oss.osbcmdb.testfixtures;
+
+import reactor.core.publisher.Mono;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceResponse;
+
+/**
+ * This service rejects any provision/update/delete which is requested with accept_incomplete=true
+ */
+public class SyncOnlyBackingSpaceInstanceInterceptor extends BaseServiceInstanceBackingSpaceInstanceInterceptor {
+
+	private static final Logger LOG = Loggers.getLogger(SyncOnlyBackingSpaceInstanceInterceptor.class);
+
+	public SyncOnlyBackingSpaceInstanceInterceptor(String defaultSpaceName) {
+		super(defaultSpaceName);
+	}
+
+	@Override
+	public Mono<CreateServiceInstanceResponse> createServiceInstance(CreateServiceInstanceRequest request) {
+		if (request.isAsyncAccepted()) {
+			throw new ServiceBrokerAsyncRequiredException("SyncOnlyBackingSpaceInstanceInterceptor is " +
+				"expecting accept_incomplete=false and abusingly returning 422 error code in this case");
+		}
+		return super.createServiceInstance(request);
+	}
+
+}

--- a/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/OsbCmdbBrokerConfigurationTest.java
+++ b/osb-cmdb/src/test/java/com/orange/oss/osbcmdb/OsbCmdbBrokerConfigurationTest.java
@@ -19,6 +19,7 @@ package com.orange.oss.osbcmdb;
 import com.orange.oss.osbcmdb.serviceinstance.MaintenanceInfoFormatterService;
 import com.orange.oss.osbcmdb.serviceinstance.ServiceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.ASyncFailedCreateBackingSpaceInstanceInterceptor;
+import com.orange.oss.osbcmdb.testfixtures.ASyncOnlyBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.ASyncStalledCreateBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.ASyncStalledDeleteBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.ASyncStalledUpdateBackingSpaceInstanceInterceptor;
@@ -29,6 +30,7 @@ import com.orange.oss.osbcmdb.testfixtures.AsyncSuccessfulUpdateBackingSpaceInst
 import com.orange.oss.osbcmdb.testfixtures.SyncFailedCreateBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncFailedDeleteBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncFailedUpdateBackingSpaceInstanceInterceptor;
+import com.orange.oss.osbcmdb.testfixtures.SyncOnlyBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncSuccessfulBackingSpaceInstanceInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncSuccessfulBackingSpaceInstanceWithoutDashboardInInitialVersionInterceptor;
 import com.orange.oss.osbcmdb.testfixtures.SyncTimeoutCreateBackingSpaceInstanceInterceptor;
@@ -115,6 +117,36 @@ class OsbCmdbBrokerConfigurationTest {
 				assertThat(context)
 					.getBean(ServiceInstanceInterceptor.class)
 					.isInstanceOf(SyncSuccessfulBackingSpaceInstanceInterceptor.class);
+			});
+	}
+
+	@Test
+	void aSyncOnlyBackingSpaceInstanceInterceptorIsCreatedWithAssociatedProfile() {
+		this.contextRunner
+			.withPropertyValues(
+				"spring.profiles.active=acceptanceTests,ASyncOnlyBackingSpaceInstanceInterceptor"
+			)
+			.withPropertyValues(requiredProperties())
+			.run((context) -> {
+				assertThat(context).hasSingleBean(ServiceInstanceInterceptor.class);
+				assertThat(context)
+					.getBean(ServiceInstanceInterceptor.class)
+					.isInstanceOf(ASyncOnlyBackingSpaceInstanceInterceptor.class);
+			});
+	}
+
+	@Test
+	void syncOnlyBackingSpaceInstanceInterceptorIsCreatedWithAssociatedProfile() {
+		this.contextRunner
+			.withPropertyValues(
+				"spring.profiles.active=acceptanceTests,SyncOnlyBackingSpaceInstanceInterceptor"
+			)
+			.withPropertyValues(requiredProperties())
+			.run((context) -> {
+				assertThat(context).hasSingleBean(ServiceInstanceInterceptor.class);
+				assertThat(context)
+					.getBean(ServiceInstanceInterceptor.class)
+					.isInstanceOf(SyncOnlyBackingSpaceInstanceInterceptor.class);
 			});
 	}
 

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateASyncInstanceRejectedBySyncBrokerAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateASyncInstanceRejectedBySyncBrokerAcceptanceTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.acceptance;
+
+import org.cloudfoundry.client.v2.ClientV2Exception;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Tag("cmdb")
+/**
+ * Validates that an osb-client provisionning request with "accept_incomplete=true" is indeed propagated to the
+ * backing service
+ */
+class CreateASyncInstanceRejectedBySyncBrokerAcceptanceTest extends CmdbCloudFoundryAcceptanceTest {
+
+	private static final String SUFFIX = "create-sync-only-instance";
+
+
+	@Override
+	protected String testSuffix() {
+		return SUFFIX;
+	}
+
+	@Test
+	@AppBrokerTestProperties({
+		"debug=true", //Spring boot debug mode
+		//osb-cmdb auth
+		"spring.security.user.name=user",
+		"spring.security.user.password=password",
+		"osbcmdb.admin.user=admin",
+		"osbcmdb.admin.password=password",
+		"spring.profiles.active=acceptanceTests,ASyncOnlyBackingSpaceInstanceInterceptor",
+		//cf java client wire traces
+		"logging.level.cloudfoundry-client.wire=debug",
+//		"logging.level.cloudfoundry-client.wire=trace",
+		"logging.level.cloudfoundry-client.operations=debug",
+		"logging.level.cloudfoundry-client.request=debug",
+		"logging.level.cloudfoundry-client.response=debug",
+		"logging.level.okhttp3=debug",
+
+		"logging.level.com.orange.oss.osbcmdb=debug",
+		"osbcmdb.dynamic-catalog.enabled=false",
+	})
+	void deployAppsAndCreateServiceKeysOnBindService() throws InterruptedException {
+		//if a request is received with an "accept_incomplete" field that is not compatible with the current backing
+		//service (accepting sync only), then make sure osb-cmdb propagates the field and the response code
+		assertThatThrownBy(() -> { cloudFoundryService.createServiceInstanceLowLevel(PLAN_NAME, appServiceName(),
+			emptyMap(), false).block(); })
+			.isInstanceOf(ClientV2Exception.class)
+			.hasMessageContaining("CF-AsyncRequired");
+	}
+
+}

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateASyncInstanceRejectedBySyncBrokerAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateASyncInstanceRejectedBySyncBrokerAcceptanceTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class CreateASyncInstanceRejectedBySyncBrokerAcceptanceTest extends CmdbCloudFoundryAcceptanceTest {
 
-	private static final String SUFFIX = "create-sync-only-instance";
+	private static final String SUFFIX = "create-async-only-instance";
 
 
 	@Override

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateSyncInstanceRejectedByAsyncBrokerAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateSyncInstanceRejectedByAsyncBrokerAcceptanceTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.acceptance;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.cloudfoundry.client.v2.ClientV2Exception;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Tag("cmdb")
+/**
+ * Validates that an osb-client provisionning request with "accept_incomplete=false" is indeed propagated to the
+ * backing service
+ */
+class CreateSyncInstanceRejectedByAsyncBrokerAcceptanceTest extends CmdbCloudFoundryAcceptanceTest {
+
+	private static final String SUFFIX = "create-sync-only-instance";
+
+
+	@Override
+	protected String testSuffix() {
+		return SUFFIX;
+	}
+
+	@Test
+	@AppBrokerTestProperties({
+		"debug=true", //Spring boot debug mode
+		//osb-cmdb auth
+		"spring.security.user.name=user",
+		"spring.security.user.password=password",
+		"osbcmdb.admin.user=admin",
+		"osbcmdb.admin.password=password",
+		"spring.profiles.active=acceptanceTests,SyncOnlyBackingSpaceInstanceInterceptor",
+		//cf java client wire traces
+		"logging.level.cloudfoundry-client.wire=debug",
+//		"logging.level.cloudfoundry-client.wire=trace",
+		"logging.level.cloudfoundry-client.operations=debug",
+		"logging.level.cloudfoundry-client.request=debug",
+		"logging.level.cloudfoundry-client.response=debug",
+		"logging.level.okhttp3=debug",
+
+		"logging.level.com.orange.oss.osbcmdb=debug",
+		"osbcmdb.dynamic-catalog.enabled=false",
+	})
+	void deployAppsAndCreateServiceKeysOnBindService() throws InterruptedException {
+		//if a request is received with an "accept_incomplete" field that is not compatible with the current backing
+		//service (accepting sync only), then make sure osb-cmdb propagates the field and the response code
+		assertThatThrownBy(() -> { cloudFoundryService.createServiceInstanceLowLevel(PLAN_NAME, appServiceName(), emptyMap(), true).block(); })
+			.isInstanceOf(ClientV2Exception.class)
+			.hasMessageContaining("CF-AsyncRequired");
+	}
+
+}


### PR DESCRIPTION
returning in orange FPC service broker rejecting the request with a 422

```
                "{\"error\":\"AsyncRequired\",\"description\":\"This service plan requires client support for asynchronous service operations.\"}\n"
          ],
```

Fixes #81

This deprecates #83 which had a rebase issue and had to be unmerged