### PR TITLE
Fix build following java8 breaking change in gradle-git-properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/osb-cmdb/build.gradle
+++ b/osb-cmdb/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 }
 
 plugins {
-	id "com.gorylenko.gradle-git-properties" version "2.2.4"
+	id "com.gorylenko.gradle-git-properties" version "2.3.2"
 }
 
 description = "Osb Cmdb"


### PR DESCRIPTION
Fix build following java8 breaking change in gradle-git-properties com.gorylenko.gradle-git-properties

See https://github.com/n0mer/gradle-git-properties/issues/195#issuecomment-985071952

Bump to 2.3.2 requires gradle bump to 6.4, see https://github.com/n0mer/gradle-git-properties/issues/193
* currently at 6.3
* spring cloud app broker at 6.5.1 [details](https://github.com/spring-cloud/spring-cloud-app-broker/blob/72f7d12b9453c93893049dfe53e2787cc9ee21c2/gradle/wrapper/gradle-wrapper.properties?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L3)

https://docs.gradle.org/current/userguide/upgrading_version_6.html
* build scan: https://scans.gradle.com/s/waqbamtsuoawc