### PR TITLE
Add ability to restrict osb requests with x-api-info-location header

### DIFF
--- a/osb-cmdb/docs/impl-notes/issue-166-x-api-info-location.md
+++ b/osb-cmdb/docs/impl-notes/issue-166-x-api-info-location.md
@@ -1,0 +1,64 @@
+
+* check how x-api-info-location is currently retrieved
+   * in CreateServiceRequest.apiInfoLocation 
+* check whether servlet filter or spring mvc equivalent can be applied on all requests
+   * https://www.baeldung.com/spring-webflux-filters#2-handlerfilterfunction
+      * q: how to restrict to only osb requests and not reject actuator requests ?
+        * by inspecting request path
+   * unit test 
+     * https://github.com/eugenp/tutorials/blob/master/spring-5-reactive/src/test/java/com/baeldung/reactive/filters/PlayerHandlerIntegrationTest.java
+   * currently using springmvc, so reactive webfilter gets ignored
+   * Pb: still needs to comply to osb api spec and return error message as json
+     * basic filter tests return 404 but without clear message 
+     * **refined filter to write plain json output**
+* explicit code in current code base
+   * ServiceInstanceController:  
+   * CatalogController: hard to intercept. This is where fast feedback would be required when operators register broker
+=> sticked to ServletFilter
+
+How to test ?
+- [x] locally start the cfapp + make manual OSB requests
+   - [ ] create new Integration test with variables
+   - [x] craft OSB requests manually: v2/catalog
+- use acceptance tests E2E framework
+   - [x] adapt CreateDeleteInstanceWithBackingServiceKeysAcceptanceTest to check current x-api-info-location: checks non-regression
+     - update locally used password (client-id has not changed)  
+   - [x] add assertions verifying invalid x-api-info-location gets rejected: BrokerRegistrationRestrictedToXApiInfoLocationAcceptanceTest which checks broker registration fails (v2/catalog)
+
+- [x] debug why the filter does not seem to load when pushed as a cf app
+  - bean is indeed loaded
+  - logger level is debug (configured to trace)
+  - traces don't display
+  - [x] gradle clean + build
+  - **environment variables not taken into account: typo/camel case**
+
+```
+osbcmdb.expectedXApiInfoLocationHeader: invalid_value_set_to_fail_catalog_fetching
+osbcmdb.rejectRequestsWithNonMatchingXApiInfoLocationHeader: true
+```
+
+## Draft User documentation
+
+With invalid cf-api-info-location fails service broker registration would fail with 
+
+```
+Creating service broker test-broker as gberche...
+Job (ac1cd040-0bef-45dd-8e38-d68c6d821eb2) failed: The service broker rejected the request. Status Code: 400 Bad Request. Please check that the URL points to a valid service broker.
+FAILED
+```
+
+The message isn't displayed by CF since this is an async job. 
+
+Checking the cf job with `cf curl v3/jobs/<jobid>` does not provide more details:
+
+```json
+"errors": [
+    {
+    "detail": "The service broker rejected the request. Status Code: 400 Bad Request. Please check that the URL points to a valid service broker.",
+    "title": "CF-ServiceBrokerRequestRejected",
+    "code": 270020
+    }
+],
+``` 
+
+It might be then necessary

--- a/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/OsbCmdbBrokerConfiguration.java
+++ b/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/OsbCmdbBrokerConfiguration.java
@@ -7,6 +7,7 @@ import com.orange.oss.osbcmdb.metadata.K8SMetadataFormatter;
 import com.orange.oss.osbcmdb.metadata.UpdateServiceMetadataFormatterService;
 import com.orange.oss.osbcmdb.servicebinding.OsbCmdbServiceBinding;
 import com.orange.oss.osbcmdb.servicebinding.ServiceBindingInterceptor;
+import com.orange.oss.osbcmdb.serviceinstance.ApiInfoLocationHeaderFilter;
 import com.orange.oss.osbcmdb.serviceinstance.MaintenanceInfoFormatterService;
 import com.orange.oss.osbcmdb.serviceinstance.OsbCmdbServiceInstance;
 import com.orange.oss.osbcmdb.serviceinstance.ServiceInstanceInterceptor;
@@ -243,5 +244,13 @@ public class OsbCmdbBrokerConfiguration {
 			osbCmdbBrokerProperties.isHideMetadataCustomParamInGetServiceInstanceEndpoint(),
 			maintenanceInfoFormatterService);
 	}
+
+	@Bean
+	public ApiInfoLocationHeaderFilter apiInfoLocationHeaderFilter(OsbCmdbBrokerProperties osbCmdbBrokerProperties) {
+		return new ApiInfoLocationHeaderFilter(osbCmdbBrokerProperties.getExpectedXApiInfoLocationHeader(),
+			osbCmdbBrokerProperties.isRejectRequestsWithNonMatchingXApiInfoLocationHeader());
+	}
+
+
 
 }

--- a/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/OsbCmdbBrokerProperties.java
+++ b/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/OsbCmdbBrokerProperties.java
@@ -17,6 +17,19 @@ public class OsbCmdbBrokerProperties {
 	 */
 	private boolean hideMetadataCustomParamInGetServiceInstanceEndpoint = true;
 
+
+	/**
+	 * Turn on to inspect X-Api-Info-Location to detect configuration mistakes from operator
+	 */
+	private boolean rejectRequestsWithNonMatchingXApiInfoLocationHeader = false;
+
+	/**
+	 * Expected X-Api-Info-Location when {@link #rejectRequestsWithNonMatchingXApiInfoLocationHeader} is set
+	 * e.g."api.example.com/v2/info"
+	 */
+	private String expectedXApiInfoLocationHeader = null;
+
+
 	public boolean isHideMetadataCustomParamInGetServiceInstanceEndpoint() {
 		return hideMetadataCustomParamInGetServiceInstanceEndpoint;
 	}
@@ -32,6 +45,23 @@ public class OsbCmdbBrokerProperties {
 
 	public void setPropagateMetadataAsCustomParam(boolean propagateMetadataAsCustomParam) {
 		this.propagateMetadataAsCustomParam = propagateMetadataAsCustomParam;
+	}
+
+	public String getExpectedXApiInfoLocationHeader() {
+		return expectedXApiInfoLocationHeader;
+	}
+
+	public void setExpectedXApiInfoLocationHeader(String expectedXApiInfoLocationHeader) {
+		this.expectedXApiInfoLocationHeader = expectedXApiInfoLocationHeader;
+	}
+
+	public boolean isRejectRequestsWithNonMatchingXApiInfoLocationHeader() {
+		return rejectRequestsWithNonMatchingXApiInfoLocationHeader;
+	}
+
+	public void setRejectRequestsWithNonMatchingXApiInfoLocationHeader(
+		boolean rejectRequestsWithNonMatchingXApiInfoLocationHeader) {
+		this.rejectRequestsWithNonMatchingXApiInfoLocationHeader = rejectRequestsWithNonMatchingXApiInfoLocationHeader;
 	}
 
 }

--- a/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/serviceinstance/ApiInfoLocationHeaderFilter.java
+++ b/osb-cmdb/src/main/java/com/orange/oss/osbcmdb/serviceinstance/ApiInfoLocationHeaderFilter.java
@@ -1,0 +1,86 @@
+package com.orange.oss.osbcmdb.serviceinstance;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ApiInfoLocationHeaderFilter extends HttpFilter  {
+
+	protected final Logger LOG = Loggers.getLogger(ApiInfoLocationHeaderFilter.class);
+
+	private String expectedXApiInfoLocationHeader;
+
+	private boolean rejectRequestsWithNonMatchingXApiInfoLocationHeader;
+
+	public ApiInfoLocationHeaderFilter(String expectedXApiInfoLocationHeader,
+		boolean rejectRequestsWithNonMatchingXApiInfoLocationHeader) {
+		this.expectedXApiInfoLocationHeader = expectedXApiInfoLocationHeader;
+		this.rejectRequestsWithNonMatchingXApiInfoLocationHeader = rejectRequestsWithNonMatchingXApiInfoLocationHeader;
+		LOG.info("Configuring ApiInfoLocationHeaderFilter with rejectRequestsWithNonMatchingXApiInfoLocationHeader={}" +
+			" and expectedXApiInfoLocationHeader={}", rejectRequestsWithNonMatchingXApiInfoLocationHeader,
+			expectedXApiInfoLocationHeader);
+	}
+
+
+	@Override
+	protected void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+		throws IOException, ServletException {
+
+		if (shouldEnforceXApiInfoLocation(request.getRequestURI())) {
+			String xApiInfoLocation = request.getHeader("X-Api-Info-Location");
+			LOG.trace("inspecting http header X-Api-Info-Location={}", xApiInfoLocation);
+
+			String expectedXApiInfoLocation = this.expectedXApiInfoLocationHeader;
+			if (! expectedXApiInfoLocation.equalsIgnoreCase(xApiInfoLocation)) {
+				LOG.error("rejecting request from X-Api-Info-Location={} whereas expecting {}", xApiInfoLocation, expectedXApiInfoLocation);
+
+				response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+				response.setHeader("Content-Type", "application/json");
+				PrintWriter writer = response.getWriter();
+				writer.write("{\"description\":\"" +
+					" Request not received from white listed osb-cmdb client." +
+					" Please, double check configuration mistakes." +
+					" Expecting X-Api-Info-Location http header value:" + expectedXApiInfoLocation+ "\"}");
+				//Note: we don't output the current header to avoid json injection from clients.
+				writer.flush();
+				response.flushBuffer();
+				return;
+			}
+		}
+		chain.doFilter(request, response);
+	}
+
+	private boolean shouldEnforceXApiInfoLocation(String requestURI) {
+		boolean shouldEnforceXApiInfoLocation= true;
+		if (rejectRequestsWithNonMatchingXApiInfoLocationHeader == false ||
+			expectedXApiInfoLocationHeader == null ||
+			expectedXApiInfoLocationHeader.isEmpty()) {
+			shouldEnforceXApiInfoLocation=false;
+		}
+		if (! requestURI.startsWith(("/v2"))) {
+			shouldEnforceXApiInfoLocation=false;
+		}
+		return shouldEnforceXApiInfoLocation;
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) {
+	}
+
+	@Override
+	public void destroy() {
+	}
+}

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/BrokerRegistrationRestrictedToXApiInfoLocationAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/BrokerRegistrationRestrictedToXApiInfoLocationAcceptanceTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.acceptance;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.cloudfoundry.client.v2.ClientV2Exception;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import reactor.core.publisher.Hooks;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("cmdb")
+class BrokerRegistrationRestrictedToXApiInfoLocationAcceptanceTest extends CmdbCloudFoundryAcceptanceTest {
+
+	private static final String SUFFIX = "incorrect-x-api-info-location-rejected";
+
+	private BrokerProperties brokerProperties;
+
+
+	@Override
+	protected String testSuffix() {
+		return SUFFIX;
+	}
+
+	@BeforeEach
+	@Override
+	void setUp(TestInfo testInfo, BrokerProperties brokerProperties) {
+		//save to use it in the test
+		this.brokerProperties = brokerProperties;
+	}
+
+	@Test
+	@AppBrokerTestProperties({
+		"debug=true", //Spring boot debug mode
+		//osb-cmdb auth
+		"spring.security.user.name=user",
+		"spring.security.user.password=password",
+		"osbcmdb.admin.user=admin",
+		"osbcmdb.admin.password=password",
+		"spring.profiles.active=acceptanceTests,SyncSuccessfulBackingSpaceInstanceInterceptor",
+		//cf java client wire traces
+		"logging.level.cloudfoundry-client.wire=debug",
+//		"logging.level.cloudfoundry-client.wire=trace",
+		"logging.level.cloudfoundry-client.operations=debug",
+		"logging.level.cloudfoundry-client.request=debug",
+		"logging.level.cloudfoundry-client.response=debug",
+		"logging.level.okhttp3=debug",
+
+		"logging.level.com.orange.oss.osbcmdb=debug",
+		"osbcmdb.dynamic-catalog.enabled=false",
+		"osbcmdb.broker.rejectRequestsWithNonMatchingXApiInfoLocationHeader=true",
+		"osbcmdb.broker.expectedXApiInfoLocationHeader=invalid_value_set_to_fail_catalog_fetching"
+	})
+	void assertServiceBrokerRegistrationFailsFromInvalidXApiLocation() throws InterruptedException {
+
+		ClientV2Exception exception =
+			assertThrows(ClientV2Exception.class, () -> {
+				Hooks.onOperatorDebug(); // get human readeable reactor stack traces
+				List<String> appBrokerProperties = getAppBrokerProperties(brokerProperties);
+				blockingSubscribe(initializeBroker(appBrokerProperties, false));
+			});
+		assertThat(exception.getMessage()).contains("The service broker rejected the request. Status Code: 400 Bad " +
+			"Request");
+
+	}
+
+	@AfterEach
+	public void tearDown(TestInfo testInfo) {
+		//override to avoid failing on error log
+		cleanUpDefaultSpace();
+	}
+
+}

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CmdbCloudFoundryAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CmdbCloudFoundryAcceptanceTest.java
@@ -1,11 +1,13 @@
 package org.springframework.cloud.appbroker.acceptance;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Hooks;
 
 import org.springframework.cloud.appbroker.acceptance.fixtures.osb.OpenServiceBrokerApiClient;
 

--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateDeleteInstanceWithBackingServiceKeysAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org/springframework/cloud/appbroker/acceptance/CreateDeleteInstanceWithBackingServiceKeysAcceptanceTest.java
@@ -65,9 +65,11 @@ class CreateDeleteInstanceWithBackingServiceKeysAcceptanceTest extends CmdbCloud
 		"logging.level.cloudfoundry-client.request=debug",
 		"logging.level.cloudfoundry-client.response=debug",
 		"logging.level.okhttp3=debug",
+		"logging.level.com.orange.oss.osbcmdb.serviceinstance.ApiInfoLocationHeaderFilter=trace",
 
 		"logging.level.com.orange.oss.osbcmdb=debug",
 		"osbcmdb.dynamic-catalog.enabled=false",
+		"osbcmdb.rejectRequestsWithNonMatchingXApiInfoLocationHeader=true"
 	})
 	void deployAppsAndCreateServiceKeysOnBindService() throws InterruptedException {
 		// given a brokered service instance is created with some params


### PR DESCRIPTION
This is to prevent configuration mistakes by operators

the following properties need to be set

```
osbcmdb.broker.expectedXApiInfoLocationHeader: invalid_value_set_to_fail_catalog_fetching
osbcmdb.broker.rejectRequestsWithNonMatchingXApiInfoLocationHeader: true
```

fixes #166